### PR TITLE
Add a list of ignores including workspace-hack

### DIFF
--- a/default.json
+++ b/default.json
@@ -5,6 +5,7 @@
     "github>oxidecomputer/renovate-config:schedule",
     "github>oxidecomputer/renovate-config:rust",
     "github>oxidecomputer/renovate-config:actions",
+    "github>oxidecomputer/renovate-config:ignores",
     ":dependencyDashboard"
   ]
 }

--- a/ignores.json
+++ b/ignores.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "description": "Ignore recommended directories + workspace-hack if it exists",
+  "ignorePaths": [
+    "workspace-hack/**",
+    "**/node_modules/**",
+    "**/bower_components/**",
+    "**/vendor/**",
+    "**/examples/**",
+    "**/__tests__/**",
+    "**/test/**",
+    "**/tests/**",
+    "**/__fixtures__/**"
+  ]
+}


### PR DESCRIPTION
This adds the [list of ignores](https://docs.renovatebot.com/presets-default/#ignoremodulesandtests) in `config:recommended`, plus workspace-hack so that changes that only target the workspace-hack are ignored.

It should be okay to enable this globally because this is not a crate that most workspaces have.