### PR TITLE
Add "dependencies" label to PRs, don't rebase off schedule

### DIFF
--- a/default.json
+++ b/default.json
@@ -7,5 +7,6 @@
     "github>oxidecomputer/renovate-config:actions",
     "github>oxidecomputer/renovate-config:ignores",
     ":dependencyDashboard"
-  ]
+  ],
+  "addLabels": ["dependencies"]
 }

--- a/schedule.json
+++ b/schedule.json
@@ -3,5 +3,6 @@
   "description": "Set schedule for automatic branch creation and merging, if enabled",
   "timezone": "America/Los_Angeles",
   "schedule": ["after 8pm", "before 6am"],
-  "automergeSchedule": ["after 8pm", "before 6am"]
+  "automergeSchedule": ["after 8pm", "before 6am"],
+  "updateNotScheduled": false
 }


### PR DESCRIPTION
I tested in https://github.com/oxidecomputer/projectv2-tests/pull/45 and
found that Renovate could also create a new label if an existing one by
the same name didn't exist, so this should never error out.

Also make it so that PR rebases don't happen off schedule.
