### PR TITLE
Add new config to pin GH actions and automatically merge some updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,9 @@ To learn more about how to include these shared config files in your own Renovat
 
 ### Pinning GitHub Actions digests
 
-We may make it requirement very soon for GitHub Actions digests to be pinned to a hash. For now, extend from `helpers:pinGitHubActionDigests` to enable this behavior.
+We may make it a requirement very soon for GitHub Actions digests to be pinned to a hash. To enable
+pinning, plus automerging updates to some allowlisted actions (to reduce developer burden), extend
+from `local>oxidecomputer/renovate-config:actions/pin` in your `renovate.json`.
 
 If you have access to Oxide RFDs, see [RFD 434](https://rfd.shared.oxide.computer/rfd/0434) for more.
 

--- a/actions/pin.json
+++ b/actions/pin.json
@@ -20,7 +20,8 @@
         "patch",
         "digest"
       ],
-      "automerge": true
+      "automerge": true,
+      "rebaseWhen": "conflicted"
     }
   ]
 }

--- a/actions/pin.json
+++ b/actions/pin.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "description": "Pin GitHub Actions digests and automatically merge allowlisted projects",
+  "extends": [
+    "helpers:pinGitHubActionDigests"
+  ],
+  "packageRules": [
+    {
+      "matchDepTypes": [
+        "action"
+      ],
+      "matchSourceUrls": [
+        "https://github.com/actions/checkout",
+        "https://github.com/taiki-e/create-gh-release-action",
+        "https://github.com/taiki-e/install-action",
+        "https://github.com/taiki-e/upload-rust-binary-action"
+      ],
+      "matchUpdateTypes": [
+        "minor",
+        "patch",
+        "digest"
+      ],
+      "automerge": true
+    }
+  ]
+}


### PR DESCRIPTION
Based on determinations in RFD 434, we've decided to always pin GitHub
Actions digests. However, I also observed in my own projects that
pinning caused a ton of noise to be generated, and that automerging
updates resulted in a much smoother experience.

We're not going to make this the default for now, but let's add a config
to pin GitHub Actions digests and automatically merge updates to some
allowlisted ones. This is strictly better than the current situation
because it provides greater legibility into the exact versions of
actions used.

## Currently allowlisted actions

* `github.com/actions/checkout`: owned by GitHub itself.
* Several actions under `github.com/taiki-e`: owned by Taiki Endo, who is a leader in the Rust community and who has done a great job managing these actions (I've been following his work for several years).

This list isn't committal and we can add to or remove from it over time.