### PR TITLE
use update-lockfile strategy for some crate specs

### DIFF
--- a/rust/README.adoc
+++ b/rust/README.adoc
@@ -12,6 +12,28 @@ This will enable:
 - Automatic branch creation for dependencies
 - Lockfile updates every Monday morning Pacific time
 
+== Updating versions for `x` or `x.y` dependencies
+
+Dependencies are often not fully specified as `x.y.z`, and instead specified as `x.y` or just a plain `x` (for crates at versions 1 or above). For example, dependencies can be specified as:
+
+[source,toml]
+```
+[dependencies]
+chrono = "0.4"
+syn = "2" 
+```
+
+For these kinds of dependencies, Renovate will not update `Cargo.lock` versions at all if the corresponding `Cargo.toml` version doesn't need to be changed. This can lead to us being behind on crate versions.
+
+To address this:
+
+* Whenever versions are specified as `x` or `x.y` in `Cargo.toml` we use the https://docs.renovatebot.com/configuration-options/#rangestrategy[`update-lockfile` range strategy]. This causes `Cargo.lock` files for such dependencies to be updated.
+* If a complete version `x.y.z` is specified, we want both the `Cargo.lock` and the `Cargo.toml` to be updated. For that, we fall back to the default `auto` strategy—which for Cargo is https://docs.renovatebot.com/modules/manager/cargo/#additional-information[almost always the same as `bump`]. (We don't want `update-lockfile` in these cases, because that won't touch `Cargo.toml`.)
+
+The above logic is implemented via a `packageRules` entry in `crates.json` which matches version specifications against a regex.
+
+It would be nice if Renovate could also change `Cargo.toml` files from `x.y` to `x.y.z` along with the `update-lockfile` strategy, but that doesn't appear to be supported in Renovate yet (as of 37.280.0).
+
 == Exclusions
 
 The following crates are currently excluded from consideration:

--- a/rust/crates.json
+++ b/rust/crates.json
@@ -11,6 +11,11 @@
       "matchDatasources": ["crate"],
       "matchPackageNames": ["vsss-rs"],
       "enabled": false
+    },
+    {
+      "matchDatasources": ["crate"],
+      "matchCurrentValue": "/^\\d+(\\.\\d+)?$/",
+      "rangeStrategy": "update-lockfile"
     }
   ]
 }


### PR DESCRIPTION
Noticed that some deps in omicron weren't getting updated. This appears to fix this, based on my tests in https://github.com/sunshowers/renovate-test/.