### PR TITLE
disable semantic commits

### DIFF
--- a/default.json
+++ b/default.json
@@ -2,11 +2,11 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "description": "Apply Oxide's global renovate preset",
   "extends": [
+    "github>oxidecomputer/renovate-config:general",
     "github>oxidecomputer/renovate-config:schedule",
     "github>oxidecomputer/renovate-config:rust",
     "github>oxidecomputer/renovate-config:actions",
     "github>oxidecomputer/renovate-config:ignores",
     ":dependencyDashboard"
-  ],
-  "addLabels": ["dependencies"]
+  ]
 }

--- a/general.json
+++ b/general.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "description": "Apply Oxide's general configuration",
+  "addLabels": ["dependencies"],
+  "semanticCommits": "disabled"
+}


### PR DESCRIPTION
Renovate keeps flipping back and forth between semantic and non-semantic commit
titles. Just turn it off for now.

I also moved the general configuration out to its own file.

Fixes #29.
