### PR TITLE
generically handle package version pinning

### DIFF
--- a/rust/crates.json
+++ b/rust/crates.json
@@ -10,7 +10,7 @@
     },
     {
       "matchDatasources": ["crate"],
-      "matchPackageNames": ["vsss-rs"],
+      "matchCurrentValue": "/^=/",
       "enabled": false
     },
     {


### PR DESCRIPTION
In https://github.com/oxidecomputer/omicron/pull/5786 I changed the version field for vsss-rs to `=3.3.4` to prevent `cargo update` (and the "lock file maintenance" Renovate task) from bumping the version. Similarly in https://github.com/oxidecomputer/omicron/pull/5926 I'm also marking sled's version dependency in the same way.

Instead of listing individual packages to ignore in the Renovate config, it seems nicer to overload the `=` sigil with the additional meaning of "hey Renovate, please ignore this crate entirely".

(Note that I am not certain how to test if this works properly.)