### PR TITLE
add iddqd, disable schemars updates

### DIFF
--- a/runner/global.json
+++ b/runner/global.json
@@ -13,6 +13,7 @@
     "oxidecomputer/dropshot-verified-body",
     "oxidecomputer/falcon",
     "oxidecomputer/four-star",
+    "oxidecomputer/iddqd",
     "oxidecomputer/maghemite",
     "oxidecomputer/microbot",
     "oxidecomputer/milestone-collector",

--- a/rust/README.adoc
+++ b/rust/README.adoc
@@ -30,6 +30,7 @@ The following crates are currently excluded from consideration:
 
 - `vsss-rs`: Relatively delicate part of omicron (trust quorum), has shipped breakages in the past.
 See https://github.com/oxidecomputer/renovate-config/issues/20[issue #20].
+- `schemars`: We are on schemars 0.8 and expect to be on this version for the foreseeable future. Hence we disable major (to 1.0) and minor (to 0.9) updates.
 
 NOTE: If you're excluding a new crate, be sure to add information about it to this section,
 including the reason(s) for exclusion.

--- a/rust/crates.json
+++ b/rust/crates.json
@@ -15,6 +15,12 @@
     },
     {
       "matchDatasources": ["crate"],
+      "matchPackageNames": ["schemars"],
+      "matchUpdateTypes": ["major", "minor"],
+      "enabled": false
+    },
+    {
+      "matchDatasources": ["crate"],
       "matchCurrentValue": "/^\\d+(\\.\\d+)?$/",
       "rangeStrategy": "update-lockfile"
     },


### PR DESCRIPTION
schemars 0.9/1.0 are pretty disruptive changes so we're planning to stay on 0.8 for now.
