### PR TITLE
Group v-api crates together

### DIFF
--- a/rust/crates.json
+++ b/rust/crates.json
@@ -26,7 +26,10 @@
     },
     {
       "matchDatasources": ["crate"],
-      "matchPackageNames": ["dropshot-api-manager", "dropshot-api-manager-types"],
+      "matchPackageNames": [
+        "dropshot-api-manager",
+        "dropshot-api-manager-types"
+      ],
       "groupName": "dropshot-api-manager"
     },
     {
@@ -45,7 +48,7 @@
     },
     {
       "matchDatasources": ["crate"],
-      "matchPackagePatterns": ["^v-api", "^v-model$"],
+      "matchPackagePatterns": ["^v-api", "^v-cli", "^v-model$"],
       "groupName": "v-api"
     }
   ]

--- a/rust/crates.json
+++ b/rust/crates.json
@@ -38,6 +38,15 @@
       "matchDatasources": ["crate"],
       "matchPackageNames": ["rand", "rand_core", "rand_distr", "rand_seeder"],
       "groupName": "rand"
+    },
+    {
+      "matchSourceUrls": ["https://github.com/oxidecomputer/v-api"],
+      "groupName": "v-api"
+    },
+    {
+      "matchDatasources": ["crate"],
+      "matchPackagePatterns": ["^v-api", "^v-model$"],
+      "groupName": "v-api"
     }
   ]
 }


### PR DESCRIPTION
I included the crate name rules in case we publish in the future, but those aren't technically required.