### PR TITLE
Add libtopo to repository allowlist

### DIFF
--- a/runner/global.json
+++ b/runner/global.json
@@ -17,6 +17,7 @@
     "oxidecomputer/four-star",
     "oxidecomputer/iddqd",
     "oxidecomputer/illumos-nvpair",
+    "oxidecomputer/libtopo",
     "oxidecomputer/maghemite",
     "oxidecomputer/mfg-support",
     "oxidecomputer/microbot",


### PR DESCRIPTION
## Summary

Adds `oxidecomputer/libtopo` to the self-hosted renovate runner's repository allowlist in `runner/global.json`.

The libtopo repo is adopting the shared renovate config in a companion PR (https://github.com/oxidecomputer/libtopo/pull/1); this entry lets the self-hosted runner actually pick it up.