### PR TITLE
PR checks for renovate configs

### DIFF
--- a/.github/workflows/renovate-config-validate.yml
+++ b/.github/workflows/renovate-config-validate.yml
@@ -20,10 +20,10 @@ jobs:
           node-version: 24
 
       - name: Validate preset files
+        # TODO: Validate runner/global.json; unsupported by renovate-config-validator
+        # Maybe a basic JSON Schema validation
         run: |
           npx --yes --package renovate -- renovate-config-validator --strict \
             *.json \
             actions/*.json \
             rust/*.json
-          # TODO: Validate runner/global.json; unsupported by renovate-config-validator
-          # Maybe a basic JSON Schema validation

--- a/.github/workflows/renovate-config-validate.yml
+++ b/.github/workflows/renovate-config-validate.yml
@@ -1,0 +1,29 @@
+name: Renovate Config Validate
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
+      - name: Validate preset files
+        run: |
+          npx --yes --package renovate -- renovate-config-validator --strict \
+            *.json \
+            actions/*.json \
+            rust/*.json
+          # TODO: Validate runner/global.json; unsupported by renovate-config-validator
+          # Maybe a basic JSON Schema validation

--- a/.github/workflows/renovate-config-validate.yml
+++ b/.github/workflows/renovate-config-validate.yml
@@ -1,4 +1,4 @@
-name: Renovate Config Validate
+name: Renovate Configs
 
 on:
   pull_request:

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -38,9 +38,9 @@ jobs:
           installation_retrieval_payload: ${{ secrets.INSTALLATION_ID }}
           private_key: ${{ secrets.PRIVATE_KEY }}
       - name: Self-hosted Renovate
+        uses: renovatebot/github-action@693b9ef15eec82123529a37c782242f091365961 # v46.1.14
         env:
           RENOVATE_TOKEN: ${{ steps.generate_token.outputs.token }}
-        uses: renovatebot/github-action@693b9ef15eec82123529a37c782242f091365961 # v46.1.14
         with:
           configurationFile: runner/global.json
           env-regex: "^(?:RENOVATE_\\w+|LOG_LEVEL)$"

--- a/actions/formatting.json
+++ b/actions/formatting.json
@@ -4,7 +4,7 @@
   "packageRules": [
     {
       "matchManagers": ["github-actions"],
-      "matchPackagePatterns": ["*"],
+      "matchPackageNames": ["*"],
       "prBodyDefinitions": {
         "Package": "[{{{depName}}}](https://github.com/{{{depName}}})",
         "Change": "[`{{{displayFrom}}}` -> `{{{displayTo}}}`](https://github.com/{{{depName}}}/compare/{{{displayFrom}}}...{{{displayTo}}})"

--- a/post-upgrade.json
+++ b/post-upgrade.json
@@ -1,13 +1,9 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "description": "Run post-upgrade script at tools/renovate-post-upgrade.sh",
-  "packageRules": [
-    {
-      "postUpgradeTasks": {
-        "commands": [
-          "tools/renovate-post-upgrade.sh"
-        ]
-      }
-    }
-  ]
+  "postUpgradeTasks": {
+    "commands": [
+      "tools/renovate-post-upgrade.sh"
+    ]
+  }
 }

--- a/runner/global.json
+++ b/runner/global.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "$schema": "https://docs.renovatebot.com/renovate-global-schema.json",
   "extends": [
     "config:recommended"
   ],

--- a/rust/autocreate.json
+++ b/rust/autocreate.json
@@ -7,7 +7,7 @@
   "packageRules": [
     {
       "matchDatasources": ["crate"],
-      "matchPackagePatterns": ["*"],
+      "matchPackageNames": ["*"],
       "dependencyDashboardApproval": false
     }
   ]

--- a/rust/crates.json
+++ b/rust/crates.json
@@ -4,7 +4,7 @@
   "packageRules": [
     {
       "matchDatasources": ["crate"],
-      "matchPackagePatterns": ["*"],
+      "matchPackageNames": ["*"],
       "dependencyDashboardApproval": true,
       "rangeStrategy": "bump"
     },
@@ -48,7 +48,7 @@
     },
     {
       "matchDatasources": ["crate"],
-      "matchPackagePatterns": ["^v-api", "^v-cli", "^v-model$"],
+      "matchPackageNames": ["/^v-api/", "/^v-cli/", "/^v-model$/"],
       "groupName": "v-api"
     }
   ]

--- a/rust/toolchain.json
+++ b/rust/toolchain.json
@@ -4,7 +4,7 @@
   "customManagers": [
     {
       "customType": "regex",
-      "fileMatch": ["^rust-toolchain\\.toml?$"],
+      "managerFilePatterns": ["/^rust-toolchain\\.toml?$/"],
       "matchStrings": [
         "channel\\s*=\\s*\"(?<currentValue>\\d+\\.\\d+(\\.\\d+)?)\""
       ],

--- a/rust/toolchain.json
+++ b/rust/toolchain.json
@@ -1,20 +1,21 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "description": "Upgrade the `channel` field in the `rust-toolchain.toml` file if present",
-  "regexManagers": [
+  "customManagers": [
     {
+      "customType": "regex",
       "fileMatch": ["^rust-toolchain\\.toml?$"],
       "matchStrings": [
         "channel\\s*=\\s*\"(?<currentValue>\\d+\\.\\d+(\\.\\d+)?)\""
       ],
       "depNameTemplate": "rust",
-      "lookupNameTemplate": "rust-lang/rust",
+      "packageNameTemplate": "rust-lang/rust",
       "datasourceTemplate": "github-releases"
     }
   ],
   "packageRules": [
     {
-      "matchManagers": ["regex"],
+      "matchManagers": ["custom.regex"],
       "matchPackageNames": ["rust"],
       "commitMessageTopic": "Rust"
     }


### PR DESCRIPTION
- Add GitHub workflow for [renovate-config-validator](https://docs.renovatebot.com/config-validation/)
- Fix `$schema` for runner/global.json
- Replace deprecated `matchPackagePatterns` with `matchPackageNames`
- Replace deprecated `regexManagers` with `customManagers` + `"customType": "regex",`
- Replace deprecated `lookupNameTemplate` with `packageNameTemplate`
- In `post-upgrade.json`, hoisted `postUpgradeTasks` out of `packageRules` as it requires a `match*` or `exclude*.`
  - Used by: [oxidecomputer/omicron](https://github.com/oxidecomputer/omicron/blob/main/tools/renovate-post-upgrade.sh)
  - Used by [oxidecomputer/projectv2-tests](https://github.com/oxidecomputer/projectv2-tests) (a test repo)
  - [Code Search for renovate-post-upgrade.sh](https://github.com/search?q=org%3Aoxidecomputer%20tools%2Frenovate-post-upgrade.sh&type=code)

NOTE: renovate-config-validator does support validating `runner/global.json`

Found a renovate bug in the process:
- https://github.com/renovatebot/renovate/pull/43327