### PR TITLE
Pin actions/setup-node

### DIFF
--- a/.github/workflows/renovate-config-validate.yml
+++ b/.github/workflows/renovate-config-validate.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
 


### PR DESCRIPTION
Pin `actions/setup-node` to the [commit hash][1] like the other actions in the repo.

[1]: https://github.com/actions/setup-node/releases/tag/v7.0.0